### PR TITLE
path_module - allow for trimming path using PROMPT_DIRTRIM

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Modules for the PS1 prompt include;
 * Battery: a battery power indicator
 * Host: shows the hostname with option for `hostname` or `username@hostname`
 * User: similar to host, but only shown when on an SSH connection
-* Path: with option for full path or current directory only
+* Path: optional arg 0 to show fullpath, 1 for the current dir and any other number to trim the path
 * Read Only: an indicator for read only directories
 * Jobs: show the number of running background jobs
 * Virtual Environment: shows the name of an active python virtual environment

--- a/example-config.conf
+++ b/example-config.conf
@@ -22,7 +22,7 @@ declare -a pureline_modules=(
     'user_module            Yellow      Black       false'   # show hostname
     'host_module            Yellow      Black       false'   # show username
 #   'virtual_env_module     Blue        Black'
-    'path_module            Blue        Black       true'   # Show full path
+    'path_module            Blue        Black       0'
     'read_only_module       Red         White'
 #   'jobs_module            Purple	    White'
 #   'git_module             Green       Black'

--- a/pureline
+++ b/pureline
@@ -95,9 +95,9 @@ function path_module {
 	local bg_color=$1
 	local fg_color=$2
 	local content="\w"
-	if [ $3 = 1 ]; then
+	if [ $3 -eq 1 ]; then
 		local content="\W"
-	elif [ $3 > 1 ]; then
+	elif [ $3 -gt 1 ]; then
 		PROMPT_DIRTRIM=$3
 	fi
 	PS1+=$(section_end $fg_color $bg_color)

--- a/pureline
+++ b/pureline
@@ -96,7 +96,8 @@ function path_module {
 	if [ "$3" = true ]; then
 		local content="\w"
 	else
-		local content="\W"
+		PROMPT_DIRTRIM=2
+		local content="\w"
 	fi
 	PS1+=$(section_end $fg_color $bg_color)
 	PS1+=$(section_content $fg_color $bg_color " $content ")

--- a/pureline
+++ b/pureline
@@ -89,13 +89,16 @@ function host_module {
 # append to prompt: current directory
 # arg: $1 foreground color
 # arg; $2 background color
-# optional arg: $3 - true/false to show fullpath
+# optional arg: $3 - 0 — fullpath, 1 — current dir, [x] — trim to x number of
+# directories
 function path_module {
 	local bg_color=$1
 	local fg_color=$2
 	local content="\w"
-	if [ "$3" != true ]; then # false will show trimmed path
-		PROMPT_DIRTRIM=2
+	if [ $3 = 1 ]; then
+		local content="\W"
+	elif [ $3 > 1 ]; then
+		PROMPT_DIRTRIM=$3
 	fi
 	PS1+=$(section_end $fg_color $bg_color)
 	PS1+=$(section_content $fg_color $bg_color " $content ")

--- a/pureline
+++ b/pureline
@@ -93,11 +93,9 @@ function host_module {
 function path_module {
 	local bg_color=$1
 	local fg_color=$2
-	if [ "$3" = true ]; then
-		local content="\w"
-	else
+	local content="\w"
+	if [ "$3" != true ]; then # false will show trimmed path
 		PROMPT_DIRTRIM=2
-		local content="\w"
 	fi
 	PS1+=$(section_end $fg_color $bg_color)
 	PS1+=$(section_content $fg_color $bg_color " $content ")


### PR DESCRIPTION
By default, when false, the `path_module` shows only the current working directory. Like this:
```
 21:58  furquan  Documents    $ 
```
I think it'd be better to show a trimmed path instead so you'd have a better idea where you are without needing to use `pwd` (while still saving screen-space when deep into a directory branch). Compare the above with this:
```
 21:58  furquan  .../sid/Documents    $  
```
Thoughts?

EDIT: I have now added the suggestion below so now the optional arg decides whether to show the fullpath, current working directory or a trimmed path decided by the value of the argument:

0 - show fullpath
1 - show only current working directory
\>1 - trim the path to _n_ directories