### PR TITLE
add pureline only once to PROMPT_COMMAND

### DIFF
--- a/pureline
+++ b/pureline
@@ -393,4 +393,4 @@ else
 fi
 
 # dynamically set the  PS1
-PROMPT_COMMAND="pureline_ps1; $PROMPT_COMMAND"
+[[ ! ${PROMPT_COMMAND} =~ 'pureline_ps1;' ]] &&  PROMPT_COMMAND="pureline_ps1; $PROMPT_COMMAND" || true


### PR DESCRIPTION
prevent pureline to be add multiple times to PROMPT_COMMAND when source it multiples times (for pureline development tests for exemple)