### PR TITLE
Dont erase the line at the end of PS1

### DIFF
--- a/pureline
+++ b/pureline
@@ -328,7 +328,7 @@ function pureline_ps1 {
 	fi
 
 	# cleanup
-	PS1+="${colors[Color_Off]}\[\e[K\] "
+	PS1+="${colors[Color_Off]} "
 	unset __last_color
 	unset __return_code
 }


### PR DESCRIPTION
Erasing the line with escape sequence K seems to prevent the reverse history to works correctly.
When we do a reverse history search with ctrl+r inside a shell and press  "escape" to undo, the line is erase instead of the normal behavior who let the user edit the command found.

This PR correct this and I don't see weird side effect until now.

Normal:
```
(reverse-i-search)`sour': source /tmp/pureline/pureline /tmp/pureline/config.conf    ----> press escape
 $  /tmp/pureline  source /tmp/pureline/pureline /tmp/pureline/config.conf 
```

Actual behavior:
```
(reverse-i-search)`sour': source /tmp/pureline/pureline /tmp/pureline/config.conf    ----> press escape
 $  /tmp/pureline 
```