### PR TITLE
Revert "add pureline only once to PROMPT_COMMAND"

### DIFF
--- a/pureline
+++ b/pureline
@@ -393,4 +393,4 @@ else
 fi
 
 # dynamically set the  PS1
-[[ ! ${PROMPT_COMMAND} =~ 'pureline_ps1;' ]] &&  PROMPT_COMMAND="pureline_ps1; $PROMPT_COMMAND" || true
+PROMPT_COMMAND="pureline_ps1; $PROMPT_COMMAND"


### PR DESCRIPTION
Reverts chris-marsh/pureline#10

I've been testing this more and its causing me problems. My config isn't being loaded when sourcing from .bashrc - I'm not sure why yet, I'll need to check it out.

Another issue ... it makes it impossible to change config on the fly by re-sourcing. 