### PR TITLE
Fix history behavior with multi-line prompt

### DIFF
--- a/pureline
+++ b/pureline
@@ -303,10 +303,11 @@ function return_code_module {
 # -----------------------------------------------------------------------------
 # append to prompt: end the current promptline and start a newline
 function newline_module {
+	__newline=1
 	if [ -n "$__last_color" ]; then
 		PS1+=$(section_end $__last_color 'Default')
 	fi
-	PS1+="\n"
+	PS1+="\[\e[K\]\n"
 	unset __last_color
 }
 
@@ -328,9 +329,14 @@ function pureline_ps1 {
 	fi
 
 	# cleanup
-	PS1+="${colors[Color_Off]}\[\e[K\] "
+	PS1+="${colors[Color_Off]} "
+	# only clear the line at the end for PS1 monoline
+	if [[ ${__newline:-0} == 0 ]];then
+		PS1+="\[\e[K\]"
+	fi
 	unset __last_color
 	unset __return_code
+	unset __newline
 }
 
 # -----------------------------------------------------------------------------

--- a/pureline
+++ b/pureline
@@ -17,7 +17,7 @@ function section_end {
 		local fg=$__last_color
 	fi
 	if [ -n "$__last_color" ]; then
-		echo "${colors[$fg]}${colors[On_$2]}$end_char"
+		echo "${colors[$fg]}${colors[On_$2]}${end_char}${colors[Color_Off]}"
 	fi
 }
 
@@ -27,7 +27,7 @@ function section_end {
 # arg: $2 background color
 # arg: $3 content
 function section_content {
-	echo "${colors[$1]}${colors[On_$2]}$3"
+	echo "${colors[$1]}${colors[On_$2]}$3${colors[Color_Off]}"
 }
 
 # -----------------------------------------------------------------------------
@@ -303,11 +303,10 @@ function return_code_module {
 # -----------------------------------------------------------------------------
 # append to prompt: end the current promptline and start a newline
 function newline_module {
-	__newline=1
 	if [ -n "$__last_color" ]; then
 		PS1+=$(section_end $__last_color 'Default')
 	fi
-	PS1+="\[\e[K\]\n"
+	PS1+="\n"
 	unset __last_color
 }
 
@@ -328,42 +327,36 @@ function pureline_ps1 {
 		PS1="$"
 	fi
 
-	# cleanup
-	PS1+="${colors[Color_Off]} "
-	# only clear the line at the end for PS1 monoline
-	if [[ ${__newline:-0} == 0 ]];then
-		PS1+="\[\e[K\]"
-	fi
+	PS1+=" "
 	unset __last_color
 	unset __return_code
-	unset __newline
 }
 
 # -----------------------------------------------------------------------------
 
 # define the basic color set
 declare -A colors=(
-[Color_Off]='\[\e[0m\]'       # Text Reset
+[Color_Off]='\[\e[0m\]\[\e[K\]'       # Text Reset
 # Foreground
-[Default]='\[\e[0;39m\]'      # Default
-[Black]='\[\e[0;30m\]'        # Black
-[Red]='\[\e[0;31m\]'          # Red
-[Green]='\[\e[0;32m\]'        # Green
-[Yellow]='\[\e[0;33m\]'       # Yellow
-[Blue]='\[\e[0;34m\]'         # Blue
-[Purple]='\[\e[0;35m\]'       # Purple
-[Cyan]='\[\e[0;36m\]'         # Cyan
-[White]='\[\e[0;37m\]'        # White
+[Default]='\[\e[0;39m\]'              # Default
+[Black]='\[\e[0;30m\]'                # Black
+[Red]='\[\e[0;31m\]'                  # Red
+[Green]='\[\e[0;32m\]'                # Green
+[Yellow]='\[\e[0;33m\]'               # Yellow
+[Blue]='\[\e[0;34m\]'                 # Blue
+[Purple]='\[\e[0;35m\]'               # Purple
+[Cyan]='\[\e[0;36m\]'                 # Cyan
+[White]='\[\e[0;37m\]'                # White
 # Background
-[On_Default]='\[\e[49m\]'     # Default
-[On_Black]='\[\e[40m\]'       # Black
-[On_Red]='\[\e[41m\]'         # Red
-[On_Green]='\[\e[42m\]'       # Green
-[On_Yellow]='\[\e[43m\]'      # Yellow
-[On_Blue]='\[\e[44m\]'        # Blue
-[On_Purple]='\[\e[45m\]'      # Purple
-[On_Cyan]='\[\e[46m\]'        # Cyan
-[On_White]='\[\e[47m\]'       # White
+[On_Default]='\[\e[49m\]'             # Default
+[On_Black]='\[\e[40m\]'               # Black
+[On_Red]='\[\e[41m\]'                 # Red
+[On_Green]='\[\e[42m\]'               # Green
+[On_Yellow]='\[\e[43m\]'              # Yellow
+[On_Blue]='\[\e[44m\]'                # Blue
+[On_Purple]='\[\e[45m\]'              # Purple
+[On_Cyan]='\[\e[46m\]'                # Cyan
+[On_White]='\[\e[47m\]'               # White
 )
 
 # define symbols


### PR DESCRIPTION
Regarding the tests done here https://github.com/chris-marsh/pureline/pull/11#issuecomment-407880221

It seems than the problem with history occur only if there is an ```\[\eK\]``` at the end of PS1 when the PS1 have multiple lines
It seems than ```\[\eK\]``` is require at the end of PS1 when the PS1 is too long to fit on the terminal or we see the background fill the whole line.

Please try this commit, it seems to works correctly with a mono or multiple line PS1.