### PR TITLE
Added module to display current aws profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Modules for the PS1 prompt include (with some environment varibale options);
 
 * Virtual Environment: shows the name of an active python virtual environment
 
+* AWS Profile: shows the current [`AWS_PROFILE`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html#using-profiles) for cli interaction with AWS.
+
 * Git: shows only when the directory is a git repository. Options are;
     * PL_GIT_DIRTY_FG=Black       
     * PL_GIT_DIRTY_BG=Yellow
@@ -75,6 +77,7 @@ All the modules are optional and can be enabled or disabled in a config file.
 * Return code from previous bash command: `⚑`
 * Number of background jobs: `⏎` followed by number
 * Python Virtual Environment:`λ`
+* AWS Profile: `☁`
 * Battery indicator when charging:`⚡`
 * Battery indicator when discharging:`▮`
 * Git Branch: ``

--- a/configs/powerline_full_256col.conf
+++ b/configs/powerline_full_256col.conf
@@ -37,6 +37,7 @@ declare -a PL_MODULES=(
     'user_module            MyLime      Black'
     'ssh_module             MyYellow    Black'
     'virtual_env_module     MyBlue      Black'
+    'aws_profile_module     MyLime      Black'
     'path_module            MyBlue      Black'
     'read_only_module       MyRed       White'
     'background_jobs_module MyPurple    White'
@@ -80,6 +81,7 @@ PL_SYMBOLS[read_only]=""
 PL_SYMBOLS[return_code]="⚑"
 PL_SYMBOLS[background_jobs]="⏎"
 PL_SYMBOLS[python]="π"
+PL_SYMBOLS[aws_profile]='☁'
 
 PL_SYMBOLS[battery_charging]="⚡"
 PL_SYMBOLS[battery_discharging]="▮"

--- a/configs/powerline_full_8col.conf
+++ b/configs/powerline_full_8col.conf
@@ -8,6 +8,7 @@ declare -a PL_MODULES=(
     'user_module            Yellow      Black'
     'ssh_module             Yellow      Black'
     'virtual_env_module     Blue        Black'
+    'aws_profile_module     Yellow      Black'
     'path_module            Blue        Black'
     'read_only_module       Red         White'
     'background_jobs_module Purple      Black'
@@ -51,6 +52,7 @@ PL_SYMBOLS[read_only]=""
 PL_SYMBOLS[return_code]="⚑"
 PL_SYMBOLS[background_jobs]="⏎"
 PL_SYMBOLS[python]="π"
+PL_SYMBOLS[aws_profile]='☁'
 
 PL_SYMBOLS[battery_charging]="⚡"
 PL_SYMBOLS[battery_discharging]="▮"

--- a/pureline
+++ b/pureline
@@ -348,6 +348,22 @@ function kubernetes_module {
 }
 
 # -----------------------------------------------------------------------------
+# append to prompt: aws profile name
+# arg: $1 foreground color
+# arg; $2 background color
+function aws_profile_module {
+    if [ -n "$AWS_PROFILE" ]; then
+        local aws_profile_name="${AWS_PROFILE}"
+        local bg_color="$1"
+        local fg_color="$2"
+        local content=" ${PL_SYMBOLS[aws_profile]} $aws_profile_name"
+        PS1+="$(section_end $fg_color $bg_color)"
+        PS1+="$(section_content $fg_color $bg_color "$content ")"
+        __last_color="$bg_color"
+    fi
+}
+
+# -----------------------------------------------------------------------------
 function pureline_ps1 {
     __return_code=$?    # save the return code
     PS1=""              # reset the command prompt
@@ -423,6 +439,7 @@ declare -A PL_SYMBOLS=(
 [background_jobs]="↨"
 [background_jobs]="↔"
 [python]="π"
+[aws_profile]='☁'
 
 [battery_charging]="■ "
 [battery_discharging]="▬ "


### PR DESCRIPTION
## New Module ##
Added a module that displays the current value of the `AWS_PROFILE` environment variable which is used to distinguish which account to use when working with amazon web services command line tools.

## Why ##
I find that when I am working with tools to interact with Amazon Web Services via the command line I am constantly switching accounts as I have various work/personal accounts to manage. It can be annoying constantly checking which account I am currently interacting with, so I have added it to this great `PS1`.

## Background ##
AWS is a cloud platform with over 1 million customers <sup>[[1]](https://techcrunch.com/2015/10/07/amazons-aws-is-now-a-7-3b-business-as-it-passes-1m-active-enterprise-customers/?guccounter=1)</sup> and is used by developers all over the world to run their code. Developers can interact with AWS via command line interface, sdks, and tools like terraform and packer.

When you want to interact with multiple AWS accounts via one machine you need to configure the command line by running configure commands, for example `aws configure --profile dev` and `aws configure --profile prod`. Then you can specify which account you want to interact with in that shell session by running `export AWS_PROFILE=dev` or `export AWS_PROFILE=prod`. This should help prevent deploying `dev` resources in a `prod` environment.

I have **not** added support for the default profile that is selected when the `AWS_PROFILE` environment variable has not been set. Instead I have opted to hide the module. This is because I do not have a default account set as it is more likely to lead to running things in the incorrect account, I believe this is best practice. (If someone only has one account then using the default is fine, but I doubt they'd need their `PS1` to statically tell them they are on the default).

See https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html for official information about how the profiles work.