### PR TITLE
Added Reflect the current directory on gnome-terminal titlebar

### DIFF
--- a/pureline
+++ b/pureline
@@ -350,6 +350,8 @@ function kubernetes_module {
 # -----------------------------------------------------------------------------
 function pureline_ps1 {
     __return_code=$?    # save the return code
+    local TITLEBAR='\[\e]2; \u@\h: \w \a';  # set console title
+    					    # example: {USERNAME}@{HOSTNAME}:{PWD}
     PS1=""              # reset the command prompt
 
     # load the modules
@@ -370,7 +372,7 @@ function pureline_ps1 {
     if [ "$PL_ERASE_TO_EOL" = true ]; then
         PS1+="\[\e[K\]"
     fi
-    PS1+=" "
+    PS1+=" ${TITLEBAR}" # set titlebar
     unset __last_color
     unset __return_code
 }


### PR DESCRIPTION
Send Pull Request for the first time.

When I used pureline at gnome-terminal, the window title was only displayed as [Terminal], and the current directory could not be displayed.
I was very anxious about this and tried to fix it, and I was able to revive beautifully.


Before
![screen-before](https://user-images.githubusercontent.com/6745680/59688701-360a6780-9219-11e9-9bad-609d49702de6.png)

After
![screen-after](https://user-images.githubusercontent.com/6745680/59754183-91436500-92c0-11e9-99b0-462630ef79a2.png)
