### PR TITLE
Add Conda environment module

### DIFF
--- a/configs/powerline_full_256col.conf
+++ b/configs/powerline_full_256col.conf
@@ -37,6 +37,7 @@ declare -a PL_MODULES=(
     'user_module            MyLime      Black'
     'ssh_module             MyYellow    Black'
     'virtual_env_module     MyBlue      Black'
+    'conda_env_module       MyBlue      Black'
     'path_module            MyBlue      Black'
     'read_only_module       MyRed       White'
     'background_jobs_module MyPurple    White'

--- a/configs/powerline_full_8col.conf
+++ b/configs/powerline_full_8col.conf
@@ -8,6 +8,7 @@ declare -a PL_MODULES=(
     'user_module            Yellow      Black'
     'ssh_module             Yellow      Black'
     'virtual_env_module     Blue        Black'
+    'conda_env_module       Blue        Black'
     'path_module            Blue        Black'
     'read_only_module       Red         White'
     'background_jobs_module Purple      Black'

--- a/configs/tty_full.conf
+++ b/configs/tty_full.conf
@@ -8,6 +8,7 @@ declare -a PL_MODULES=(
     'user_module            Yellow      Black'
     'ssh_module             Yellow      Black'
     'virtual_env_module     Blue        Black'
+    'conda_env_module       Blue        Black'
     'path_module            Blue        Black'
     'read_only_module       Red         White'
     'background_jobs_module Purple      Black'

--- a/pureline
+++ b/pureline
@@ -259,6 +259,22 @@ function virtual_env_module {
 }
 
 # -----------------------------------------------------------------------------
+# append to prompt: conda virtual environment name
+# arg: $1 foreground color
+# arg; $2 background color
+function conda_env_module {
+    if ! [ "$CONDA_SHLVL" -eq "0" ]; then
+        local venv="${CONDA_DEFAULT_ENV##*/}"
+        local bg_color="$1"
+        local fg_color="$2"
+        local content=" ${PL_SYMBOLS[python]} $venv"
+        PS1+="$(section_end $fg_color $bg_color)"
+        PS1+="$(section_content $fg_color $bg_color "$content ")"
+        __last_color="$bg_color"
+    fi
+}
+
+# -----------------------------------------------------------------------------
 # append to prompt: indicator for battery level
 # arg: $1 foreground color
 # arg; $2 background color


### PR DESCRIPTION
This adds a very very simple module (based off the code for the `virtual_env_module`) to highlight the name of the **[Conda](https://docs.conda.io/en/latest/)** environment you are in.

For the unaware: Conda environments are very similar to virtualenvs but they are a different beast as they can also handle non-Python software, or even the version of Python itself. They are very powerful.
