### PR TITLE
Don't clobber readline mode indicator

### DIFF
--- a/pureline
+++ b/pureline
@@ -441,7 +441,8 @@ if [ -z "$PL_MODULES" ]; then
     )
     PL_USER_SHOW_HOST=true
     PL_PATH_TRIM=1
-    PL_ERASE_TO_EOL=true
+    # don't clobber readline mode indicator
+    [[ $(bind -v) =~ "set show-mode-in-prompt off" ]] && PL_ERASE_TO_EOL=true
 fi
 
 # grab a snapshot of the systems PROMPT_COMMAND. this can then be


### PR DESCRIPTION
`$PL_ERASE_TO_EOL` does not play nicely with the readline 'set
show-mode-in-prompt' option. For example, all entered text in vi cmd
mode is set to the background color, rendering the input invisible.

Use the bash built-in `bind` command to check if this option is off
before setting `$PL_ERASE_TO_EOL`.

Enter the following to test:
```
set -o vi
bind 'set show-mode-in-prompt on'
```

When `PL_ERASE_TO_EOL=true`, you can type some text and press <kbd>esc</kbd> to enter vi cmd mode and see that the text disappears. Set `PL_ERASE_TO_EOL=false` and the problem is resolved.

Another option is to remove the default `$PL_ERASE_TO_EOL` value, set this variable in the example configurations files, and document what it does.