### PR TITLE
Add module to display "screen" session

### DIFF
--- a/configs/powerline_full_256col.conf
+++ b/configs/powerline_full_256col.conf
@@ -36,6 +36,7 @@ declare -a PL_MODULES=(
     'battery_module         MyBlue      Black'
     'user_module            MyLime      Black'
     'ssh_module             MyYellow    Black'
+    'screen_session_module  MyBlue      Black'
     'virtual_env_module     MyBlue      Black'
     'path_module            MyBlue      Black'
     'read_only_module       MyRed       White'

--- a/configs/powerline_full_8col.conf
+++ b/configs/powerline_full_8col.conf
@@ -7,6 +7,7 @@ declare -a PL_MODULES=(
     'battery_module         Blue        Black'
     'user_module            Yellow      Black'
     'ssh_module             Yellow      Black'
+    'screen_session_module  Blue        Black'
     'virtual_env_module     Blue        Black'
     'path_module            Blue        Black'
     'read_only_module       Red         White'

--- a/configs/tty_full.conf
+++ b/configs/tty_full.conf
@@ -7,6 +7,7 @@ declare -a PL_MODULES=(
     'battery_module         Blue        Black'
     'user_module            Yellow      Black'
     'ssh_module             Yellow      Black'
+    'screen_session_module  Blue        Black'
     'virtual_env_module     Blue        Black'
     'path_module            Blue        Black'
     'read_only_module       Red         White'

--- a/pureline
+++ b/pureline
@@ -111,6 +111,22 @@ function ssh_module {
 }
 
 # -----------------------------------------------------------------------------
+# append to prompt: "screen" session name
+# arg: $1 foreground color
+# arg; $2 background color
+function screen_session_module {
+    if [[ "$TERM" == screen.* ]]; then
+        local session="${STY}"
+        local bg_color="$1"
+        local fg_color="$2"
+        local content=" ${PL_SYMBOLS[screen]} $session"
+        PS1+="$(section_end $fg_color $bg_color)"
+        PS1+="$(section_content $fg_color $bg_color "$content ")"
+        __last_color="$bg_color"
+    fi
+}
+
+# -----------------------------------------------------------------------------
 # append to prompt: current directory
 # arg: $1 foreground color
 # arg; $2 background color
@@ -428,6 +444,7 @@ declare -A PL_SYMBOLS=(
 [git_conflicts]="*"
 
 [ssh]="╤"
+[screen]="💻"
 [read_only]="Θ"
 [return_code]="x"
 [background_jobs]="↨"


### PR DESCRIPTION
I really like how the ssh module reminds me _visibly_ that I'm somewhere else, so I thought it would be nice to have something similar for "screen" sessions as they do not otherwise have any obvious signs that tell you you're in one (unlike say tmux, which renders a bar at the bottom.)
