### PR TITLE
check if git is installed to prevent error message

### DIFF
--- a/segments/git_segment
+++ b/segments/git_segment
@@ -27,6 +27,8 @@
 #   PL_GIT_UNTRACKED: true/false
 function git_segment {
     local git_branch
+    which git >/dev/null 2>&1 || return;  ## return if no git
+
     git_branch=$(git rev-parse --abbrev-ref HEAD 2> /dev/null)
     
     [[ -z $git_branch  ]] && return;  ## return early if not a git branch


### PR DESCRIPTION
Using a global home directory on different computers, raised an error message when logging into a machine without git installed