### PR TITLE
Compatibility with bash version before 4.4

### DIFF
--- a/pureline
+++ b/pureline
@@ -210,7 +210,11 @@ function newline_segment {
 # code to run before processing $PROMT_COMMAND
 function pureline_pre {
     __return_code=$?                    # save return code of last command
-    echo -ne "\e]2;${PL_TITLEBAR@P}\a"  # set the gui window title
+    if (( ${BASH_VERSINFO[0]:-0} > 4 || (${BASH_VERSINFO[0]:-0} == 4 && ${BASH_VERSINFO[1]:-0} >= 4) )); then
+        echo -ne "\e]2;${PL_TITLEBAR@P}\a"  # set the gui window title
+    else
+        echo -ne "\e]2;'${PL_TITLEBAR}'\a"  # set the gui window title
+    fi
 }
 
 # -----------------------------------------------------------------------------

--- a/segments/pwd_segment
+++ b/segments/pwd_segment
@@ -17,7 +17,8 @@ function pwd_segment {
     local bg_color="$1"
     local fg_color="$2"
     #local content="\w"
-    local content="${PWD/#$HOME/\~}" #$(pwd)
+    local content="${PWD/#$HOME/~}" #works for bash < 4.4 #$(pwd)
+    content="${content/#$HOME/\~}" #escaping needed for bash >= 4.4 
     if [ "$PL_PATH_TRIM" -eq 1 ]; then
     #    local content="\W"
         content="${content##*/}"

--- a/segments/pwd_segment
+++ b/segments/pwd_segment
@@ -18,7 +18,7 @@ function pwd_segment {
     local fg_color="$2"
     #local content="\w"
     local content="${PWD/#$HOME/~}" #works for bash < 4.4 #$(pwd)
-    content="${content/#$HOME/\~}" #escaping needed for bash >= 4.4 
+    content="${content/#$HOME/\~}" #escaping needed for bash >= 4.4
     if [ "$PL_PATH_TRIM" -eq 1 ]; then
     #    local content="\W"
         content="${content##*/}"


### PR DESCRIPTION
In older bash version ```GNU bash, version 4.2.46(2)-release (x86_64-redhat-linux-gnu)``` I got an error:
```bash: \e]2;${PL_TITLEBAR@P}\a: bad substitution```