### PR TITLE
Allowing TMUX pane titles to persist

### DIFF
--- a/pureline
+++ b/pureline
@@ -210,6 +210,10 @@ function newline_segment {
 # code to run before processing $PROMT_COMMAND
 function pureline_pre {
     __return_code=$?                    # save return code of last command
+    
+    # If using tmux, allow pane titles to persist
+    [ -n "$TMUX" ] && return 0
+    
     if (( ${BASH_VERSINFO[0]:-0} > 4 || (${BASH_VERSINFO[0]:-0} == 4 && ${BASH_VERSINFO[1]:-0} >= 4) )); then
         echo -ne "\e]2;${PL_TITLEBAR@P}\a"  # set the gui window title
     else


### PR DESCRIPTION
When running within tmux, attempt the following at the prompt
    
    ```bash
    > tmux set -g pane-border-status bottom
    > tmux set -g allow-rename off
    > tmux set -g pane-border-format "< #T >"
    > tmux split-window
    
    > tmux select-pane -T "New Title"
    ```    
Prior to this change, the pureline_pre function is constantly setting the gui window title.  This is the same value that TMUX uses to determine the pane title.  This 'resetting' of the xterm title overwrites the tmux pane title.  For this reason, and only within properly branded TMUX sessions, we do not reset the window title.