### PR TITLE
Fix "No segments Loaded" when last segment is 'newline_segment'

### DIFF
--- a/pureline
+++ b/pureline
@@ -228,7 +228,7 @@ function pureline_ps1 {
     done
 
     # final end point
-    if [ -n "$__last_color" ]; then
+    if ((${#PL_SEGMENTS[@]} > 0)); then
         PS1+="$(segment_end "$__last_color" 'Default') "
     else
         # No segments loaded, set a basic prompt


### PR DESCRIPTION
When you set 'newline_segment' as your last segment, the prompt displayed error message "PL | No segments Loaded" instead of your segments.