### PR TITLE
Fixes when inherited PROMPT_COMMAND is not empty

### DIFF
--- a/pureline
+++ b/pureline
@@ -208,7 +208,7 @@ function newline_segment {
 
 # -----------------------------------------------------------------------------
 # code to run before processing the inherited $PROMPT_COMMAND
-function pureline_pre {
+function __pureline_pre {
     __return_code=$?                    # save return code of last command
     if (( ${BASH_VERSINFO[0]:-0} > 4 || (${BASH_VERSINFO[0]:-0} == 4 && ${BASH_VERSINFO[1]:-0} >= 4) )); then
         echo -ne "\e]2;${PL_TITLEBAR@P}\a"  # set the gui window title
@@ -220,7 +220,7 @@ function pureline_pre {
 
 # -----------------------------------------------------------------------------
 # code to run after processing the inherited $PROMPT_COMMAND
-function pureline_post {
+function __pureline_post {
     local segment_index
     PS1=""                                  # reset the command prompt
 
@@ -338,9 +338,9 @@ function main() {
     if [[ ! ${PROMPT_COMMAND} =~ 'pureline_ps1' ]]; then
         eval "$(echo -e "
             function pureline_ps1 {
-                pureline_pre
+                __pureline_pre
                 $PROMPT_COMMAND
-                pureline_post
+                __pureline_post
             }
         ")"
         PROMPT_COMMAND="pureline_ps1"

--- a/pureline
+++ b/pureline
@@ -207,7 +207,7 @@ function newline_segment {
 }
 
 # -----------------------------------------------------------------------------
-# code to run before processing $PROMT_COMMAND
+# code to run before processing the inherited $PROMPT_COMMAND
 function pureline_pre {
     __return_code=$?                    # save return code of last command
     if (( ${BASH_VERSINFO[0]:-0} > 4 || (${BASH_VERSINFO[0]:-0} == 4 && ${BASH_VERSINFO[1]:-0} >= 4) )); then
@@ -215,10 +215,12 @@ function pureline_pre {
     else
         echo -ne "\e]2;'${PL_TITLEBAR}'\a"  # set the gui window title
     fi
+    return $__return_code  # forward it to the inherited $PROMPT_COMMAND
 }
 
 # -----------------------------------------------------------------------------
-function pureline_ps1 {
+# code to run after processing the inherited $PROMPT_COMMAND
+function pureline_post {
     local segment_index
     PS1=""                                  # reset the command prompt
 
@@ -332,13 +334,19 @@ function main() {
         fi
     done
 
-    # dynamically set the  PS1
-    # shellcheck disable=SC2015
-    if [[ ! "${PROMPT_COMMAND}" =~ 'pureline_ps1' ]]; then
-        # TODO strip trailing whitespace from PROMPT_COMMAND and check 
-        # if last char is a semicolon
-        [[ ! ${#PROMPT_COMMAND} -eq 0 ]] && PROMPT_COMMAND+=";"
-        PROMPT_COMMAND="pureline_pre; $PROMPT_COMMAND pureline_ps1;"
+    # dynamically set the PS1
+    if [[ ! ${PROMPT_COMMAND} =~ 'pureline_ps1' ]]; then
+        eval "$(echo -e "
+            function pureline_ps1 {
+                pureline_pre
+                $PROMPT_COMMAND
+                pureline_post
+            }
+        ")"
+        PROMPT_COMMAND="pureline_ps1"
+        # Note: defining PROMPT_COMMAND as a call to a single function simplifies a lot
+        #   the integration of pureline in other prompt-modifying tools 
+        #   (like the 'shell integration' feature of the integrated terminals of VSCode).
     fi
 }
 


### PR DESCRIPTION
**[FIX-1]** 
function 'pureline_pre' now returns the saved error code of the last executed command.
=> Does not break an inherited PROMPT_COMMAND that requires that value.

**[FIX-2]** 
Defines PROMPT_COMMAND as a call to a _single_ function, which is dynamically generated using 'eval' in a robust way, so as to work whatever the content of the inherited PROMPT_COMMAND.
    => No need to strip trailing whitespaces
    => No need to check/add a trailing semicolon
    => No need to handle any other (undiscovered) special case

**Note**: the "new" function is called 'pureline_ps1', while the "old" one is renamed 'pureline_post'.
