### PR TITLE
Don't set the GUI window title if PL_TITLEBAR is empty

### DIFF
--- a/pureline
+++ b/pureline
@@ -209,10 +209,13 @@ function newline_segment {
 # code to run before processing the inherited $PROMPT_COMMAND
 function __pureline_pre {
     __return_code=$?                    # save return code of last command
-    if (( ${BASH_VERSINFO[0]:-0} > 4 || (${BASH_VERSINFO[0]:-0} == 4 && ${BASH_VERSINFO[1]:-0} >= 4) )); then
-        echo -ne "\e]2;${PL_TITLEBAR@P}\a"  # set the gui window title
-    else
-        echo -ne "\e]2;'${PL_TITLEBAR}'\a"  # set the gui window title
+    if [[ -n $PL_TITLEBAR ]]; then
+        if ((${BASH_VERSINFO[0]:-0} > 4 || (${BASH_VERSINFO[0]:-0} == 4 && ${BASH_VERSINFO[1]:-0} >= 4))); then
+            # since bash 4.4, @P allows variable expansion as if it were a prompt string (like PS1)
+            echo -ne "\e]2;${PL_TITLEBAR@P}\a"  # set the gui window title
+        else
+            echo -ne "\e]2;'${PL_TITLEBAR}'\a"  # set the gui window title
+        fi
     fi
     return $__return_code  # forward it to the inherited $PROMPT_COMMAND
 }


### PR DESCRIPTION
NOTE: 
This fix also offer users a simple way to prevent **pureline** from updating the GUI window title:
they just have to unset PL_TITLEBAR in their config file.

Pull request  https://github.com/chris-marsh/pureline/pull/66 _"Allowing TMUX pane titles to persist"_ describes one case where it is desirable.