### PR TITLE
Use git on Windows for Windows folder on WSL

### DIFF
--- a/segments/git_segment
+++ b/segments/git_segment
@@ -14,6 +14,37 @@
 [[ -z ${PL_SYMBOLS[git_conflicts]} ]] && PL_SYMBOLS[git_conflicts]="*"
 
 # -----------------------------------------------------------------------------
+# detect if we are currently in a WSL environment
+function is_wsl {
+  if [[ -n "$IS_WSL" || -n "$WSL_DISTRO_NAME" ]]; then
+    echo return $(true)
+  else
+    echo return $(false)
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# detect if the current directory is mounted from Windows filesystem
+function is_win_dir {
+  case $PWD/ in
+    /mnt/*) return $(true);;
+    *) return $(false);;
+  esac
+}
+
+# -----------------------------------------------------------------------------
+# use git on Windows instead of the linux installation if the current directory
+# is mounted from Windows filesystem on WSL
+function git {
+  if is_wsl && is_win_dir
+  then
+    git.exe "$@"
+  else
+    /usr/bin/git "$@"
+  fi
+}
+
+# -----------------------------------------------------------------------------
 # append to prompt: git branch with indicators for;
 #     number of; modified files, staged files and conflicts
 # arg: $1 background color


### PR DESCRIPTION
Due to microsoft/WSL#4401, when we switch to a directory mounted from the Windows filesystem on WSL2, the git segment is very slow. For large repositories, this can hang the whole terminal.

This patch detects if we are in a WSL environment and if the current folder is mounted from the Windows filesystem. If those criteria are true, we use the `git.exe` binary in the git segment instead of the one installed in Linux.

There is a limitation to this approach. If we mount another filesystem under `/mnt` in WSL, the changes here also try to use `git.exe`.