### PR TITLE
Right-aligned segments, flexible date/time format

### DIFF
--- a/configs/demureline_right_256col.conf
+++ b/configs/demureline_right_256col.conf
@@ -1,0 +1,105 @@
+# Full example config for PureLine using default powerline symbols
+# custom 256 color and right-aligned section with clocks and git info
+
+# Colors must be defined in pairs of FG & BG
+PL_COLORS[MyOrange]='\[\e[38;5;208m\]'
+PL_COLORS[On_MyOrange]='\[\e[48;5;208m\]'
+
+PL_COLORS[MyLime]='\[\e[38;5;119m\]'
+PL_COLORS[On_MyLime]='\[\e[48;5;119m\]'
+
+PL_COLORS[MyYellow]='\[\e[38;5;227m\]'
+PL_COLORS[On_MyYellow]='\[\e[48;5;227m\]'
+
+PL_COLORS[MyLightGrey]='\[\e[38;5;250m\]'
+PL_COLORS[On_MyLightGrey]='\[\e[48;5;250m\]'
+
+PL_COLORS[MyBlue]='\[\e[38;5;69m\]'
+PL_COLORS[On_MyBlue]='\[\e[48;5;69m\]'
+
+PL_COLORS[MyRed]='\[\e[38;5;196m\]'
+PL_COLORS[On_MyRed]='\[\e[48;5;196m\]'
+
+PL_COLORS[MyDarkGrey]='\[\e[38;5;240m\]'
+PL_COLORS[On_MyDarkGrey]='\[\e[48;5;240m\]'
+
+PL_COLORS[MyPurple]='\[\e[38;5;89m\]'
+PL_COLORS[On_MyPurple]='\[\e[48;5;89m\]'
+
+PL_COLORS[MyGreen]='\[\e[38;5;83m\]'
+PL_COLORS[On_MyGreen]='\[\e[48;5;83m\]'
+
+# All segments are enabled. Uncomment/comment to enable/disable a segment
+PL_SEGMENTS=(
+    # segment                Background  Foreground
+    # -------                ----------  ----------
+    'right_align_segment'
+    'return_code_segment     MyRed       White'
+    'git_segment             MyGreen     Black'
+    'background_jobs_segment MyPurple    White'
+    'duration_segment        MyDarkGrey  White'
+    'time_segment            MyLightGrey Black'
+    'battery_segment         MyBlue      Black'
+    'right_align_end_segment'
+    'user_segment            MyLime      Black'
+    'ssh_segment             MyYellow    Black'
+    'path_segment            MyBlue      Black'
+    'screen_session_segment  MyLightGrey Black'
+    'virtual_env_segment     MyBlue      Black'
+    'conda_env_segment       MyBlue      Black'
+    'aws_profile_segment     MyLime      Black'
+    'kubernetes_segment      MyLime      Black'
+    'newline_segment'
+    'read_only_segment       MyRed       White'
+    'prompt_segment          MyDarkGrey  White'
+)
+
+# segment Options
+PL_PATH_TRIM=3             # 0 Full path, 1, Current, 2+ trim level
+PL_TIME_SHOW_SECONDS=true
+PL_TIME_FORMAT="%I:%M:%S%P"
+PL_USER_SHOW_HOST=true
+PL_USER_USE_IP=false
+PL_SSH_SHOW_HOST=true
+PL_SSH_USE_IP=true
+PL_GIT_DIRTY_FG=Black
+PL_GIT_DIRTY_BG=MyOrange
+PL_GIT_AHEAD=true
+PL_GIT_MODIFIED=true
+PL_GIT_STAGED=true
+PL_GIT_CONFLICTS=true
+PL_GIT_UNTRACKED=true
+PL_GIT_STASH=true
+PL_PROMPT_ROOT_BG=Red
+PL_PROMPT_ROOT_FG=White
+
+# redefine symbols using powerline glyphs
+PL_SYMBOLS[hard_separator]=""
+PL_SYMBOLS[soft_separator]=""
+PL_SYMBOLS[hard_separator_r]=""
+PL_SYMBOLS[soft_separator_r]=""
+
+PL_SYMBOLS[git_branch]=""
+PL_SYMBOLS[git_untracked]="↔"
+PL_SYMBOLS[git_stash]="§"
+PL_SYMBOLS[git_ahead]="↑"
+PL_SYMBOLS[git_behind]="↓"
+PL_SYMBOLS[git_modified]="✚ "
+PL_SYMBOLS[git_staged]="✔ "
+PL_SYMBOLS[git_conflicts]="✘ "
+
+PL_SYMBOLS[read_only]=""
+PL_SYMBOLS[return_code]="⚑"
+PL_SYMBOLS[background_jobs]="⏎"
+
+PL_SYMBOLS[battery_charging]="⚡"
+PL_SYMBOLS[battery_discharging]="▮"
+
+PL_SYMBOLS[aws_profile]='☁'
+PL_SYMBOLS[screen]='💻'
+PL_SYMBOLS[duration]='⏳'
+
+PL_SYMBOLS[pwd_separator]=''
+PL_SYMBOLS[pwd_trimmed]=''
+
+PL_WIDE_SYMBOLS+='💻'

--- a/pureline
+++ b/pureline
@@ -14,17 +14,35 @@ unset PL_SEGMENTS; declare -a PL_SEGMENTS  # Array to hold segments and their ar
 function segment_end {
     local end_char
     local fg
-    if [ "$__last_color" == "$2" ]; then
-        # segment colors are the same, use a foreground separator
-        end_char="${PL_SYMBOLS[soft_separator]}"
-        fg="$1"
-    else
-        # segment colors are different, use a background separator
-        end_char="${PL_SYMBOLS[hard_separator]}"
-        fg="$__last_color"
-    fi
-    if [ -n "$__last_color" ]; then
-        echo "${PL_COLORS[$fg]}${PL_COLORS[On_$2]}$end_char"
+    if [ "$__right_align_segment" == "" ]; then # regular segment, right facing arrows
+        if [ "$__last_color" == "$2" ]; then
+            # segment colors are the same, use a foreground separator
+            end_char="${PL_SYMBOLS[soft_separator]}"
+            fg="$1"
+        else
+            # segment colors are different, use a background separator
+            end_char="${PL_SYMBOLS[hard_separator]}"
+            fg="$__last_color"
+        fi
+        if [ -n "$__last_color" ]; then
+            echo "${PL_COLORS[$fg]}${PL_COLORS[On_$2]}$end_char"
+        fi
+    else # right-aligned segment, reverse arrows
+        if [ "$__last_color" == "$2" ]; then
+            # segment colors are the same, use a foreground separator
+            end_char="${PL_SYMBOLS[soft_separator]}"
+            fg="$1"
+        else
+            # segment colors are different, use a background separator
+            end_char="${PL_SYMBOLS[hard_separator]}"
+            fg="$2"
+        fi
+        if [ -n "$__last_color" ]; then
+            echo "${PL_COLORS[$fg]}${PL_COLORS[On_$__last_color]}$end_char"
+        else
+            echo "${PL_COLORS[$fg]}${PL_COLORS[On_Default]}$end_char"
+        fi
+
     fi
 }
 
@@ -34,7 +52,6 @@ function segment_end {
 # arg: $2 background color
 # arg: $3 content
 function segment_content {
-    __last_color="$2"
     echo "${PL_COLORS[$1]}${PL_COLORS[On_$2]}$3"
 }
 
@@ -70,15 +87,23 @@ function prompt_char {
 # arg: $1 background color
 # arg: $2 foreground color
 # optional variables;
-#   PL_TIME_SHOW_SECONDS: true/false for hh:mm:ss / hh:mm
+#   PL_TIME_FORMAT: date/time format suitable for 'date' command
+#   PL_TIME_SHOW_SECONDS: true/false for hh:mm:ss / hh:mm, if PL_TIME_FORMAT is
+#                         not set (legacy configs)
 function time_segment {
     local bg_color="$1"
     local fg_color="$2"
-    if [ "$PL_TIME_SHOW_SECONDS" = true ]; then
-        local content="\t"
+
+    if [ "$PL_TIME_FORMAT" = "" ]; then
+        if [ "$PL_TIME_SHOW_SECONDS" = true ]; then
+            local time_format="%H:%M:%S" # HH:MM:SS
+        else
+            local time_format="%H:%M"
+        fi
     else
-        local content="\A"
+        local time_format="$PL_TIME_FORMAT"
     fi
+    local content=`date "+$time_format"`
     PS1+="$(segment_end "$fg_color" "$bg_color")"
     PS1+="$(segment_content "$fg_color" "$bg_color" " $content ")"
     __last_color="$bg_color"
@@ -94,13 +119,13 @@ function time_segment {
 function user_segment {
     local bg_color="$1"
     local fg_color="$2"
-    local content="\u"
+    local content="`whoami`"
     # Show host if true or when user is remote/root
     if [ "$PL_USER_SHOW_HOST" = true ]; then
         if [ "$PL_USER_USE_IP" = true ]; then
             content+="@$(ip_address)"
         else
-            content+="@\h"
+            content+="@`hostname`"
         fi
     fi
     PS1+="$(segment_end "$fg_color" "$bg_color")"
@@ -226,6 +251,42 @@ function newline_segment {
 }
 
 # -----------------------------------------------------------------------------
+# start the right-aligned portion of the prompt
+function right_align_segment {
+    # Save the $PS1 portion we have so far
+    __right_align_segment="1"
+    __right_align_ps1_save=$PS1
+    PS1=""
+    # Swap the separator characters
+    __right_align_hard_save="${PL_SYMBOLS[hard_separator]}"
+    PL_SYMBOLS[hard_separator]="${PL_SYMBOLS[hard_separator_r]}"
+    __right_align_soft_save="${PL_SYMBOLS[soft_separator]}"
+    PL_SYMBOLS[soft_separator]="${PL_SYMBOLS[soft_separator_r]}"
+}
+
+# -----------------------------------------------------------------------------
+# ends the right-aligned portion of the prompt
+function right_align_end_segment {
+
+    [ -n "$__right_align_segment" ] || return 0 # bail if we are not in right align mode
+    
+    # calculate offset based on printable character count (erase control chars), and shift what we got by that
+    # we will also take into account the characters that occupy 2 spaces - those should be listed in PL_WIDE_SYMBOLS
+    local PS1_printable=$(echo "$PS1" | sed -E 's/\\\[[^]]*]//g' | sed -E 's/\\\\/\\/g' | sed 's/\(['$PL_WIDE_SYMBOLS']\)/\1!/g' )
+    local indent=$(($COLUMNS-${#PS1_printable}))
+    local indent_sequence="\\[\\e[${indent}C\\]"
+
+    PS1="${__right_align_ps1_save}${indent_sequence}${PS1}\r"
+
+    # Restore the separator characters
+    PL_SYMBOLS[hard_separator]="$__right_align_hard_save"
+    PL_SYMBOLS[soft_separator]="$__right_align_soft_save"
+
+    unset __last_color
+    unset __right_align_segment
+}
+
+# -----------------------------------------------------------------------------
 # code to run before processing the inherited $PROMPT_COMMAND
 function __pureline_pre {
     __return_code=$?                    # save return code of last command
@@ -304,13 +365,16 @@ function set_default_colors() {
 function set_default_symbols {
     PL_SYMBOLS=(
         [hard_separator]="▶"
+        [hard_separator_r]="◀"
         [soft_separator]="│"
+        [soft_separator_r]="│"
 
         [read_only]="Θ"
         [return_code]="x"
         [background_jobs]="↨"
         [background_jobs]="↔"
     )
+    PL_WIDE_SYMBOLS="💻⏳⚡☁🛜"
 }
 
 # -----------------------------------------------------------------------------

--- a/segments/ssh_segment
+++ b/segments/ssh_segment
@@ -22,7 +22,7 @@ function ssh_segment {
             if [ "$PL_SSH_USE_IP" = true ]; then
                 content+=" $(ip_address)"
             else
-                content+=" \h"
+                content+=" $(hostname)"
             fi
         fi
         PS1+="$(segment_end "$fg_color" "$bg_color")"


### PR DESCRIPTION
This adds `right_align_segment` and `right_align_end_segment` that allow the segments listed between these two to be displayed right-justified at the right side of the console window,  like so:

![image](https://github.com/user-attachments/assets/05481c61-3da3-4c15-ac0e-a255913a51a2)

I did not submit readme changes, but they are in https://github.com/m1tk4/demureline/commit/b03fb7154cfb6d898ff6897fdbececba372275f0 

Note that line 37 https://github.com/chris-marsh/pureline/compare/main...m1tk4:demureline:feature/right-align#diff-41b090d3dd5adfc4595c4568777d78745aa5757a5e3ad810ac0798227080c5c0L37 is deleted because this function is always executed in a subshell and cannot modify parent's `__last_color` variable anyway. Very confusing.

Thank you, hope you'll find this useful.

