### PR TITLE
feat(git-segment): show tag names for current HEAD commits

### DIFF
--- a/segments/git_segment
+++ b/segments/git_segment
@@ -37,6 +37,17 @@ function git_segment {
     local fg_color="$2"
     local content="${PL_SYMBOLS[git_branch]} $git_branch"
 
+    if [ "${PL_GIT_TAG:-true}" = true ]; then
+	    git_tag="$(git tag --points-at HEAD 2>/dev/null)"
+	    if [ -n "$git_tag" ]; then
+		    if [ "$git_branch" == "HEAD" ]; then
+			    content="${PL_SYMBOLS[git_branch]} $git_tag"
+		    else
+			    content+= " $git_tag"
+		    fi
+	    fi
+    fi
+
     if [ "$PL_GIT_STASH" = true ]; then
         local number_stash
         number_stash="$(git stash list 2>/dev/null | grep -F -v -c 'fatal:' | tr -d '[:space:]')"

--- a/segments/git_segment
+++ b/segments/git_segment
@@ -43,7 +43,7 @@ function git_segment {
 		    if [ "$git_branch" == "HEAD" ]; then
 			    content="${PL_SYMBOLS[git_branch]} $git_tag"
 		    else
-			    content+= " $git_tag"
+			    content+=" $git_tag"
 		    fi
 	    fi
     fi


### PR DESCRIPTION
Expose Git tag information in the prompt when `PL_GIT_TAG` is enabled by checking tags that point at `HEAD`. When the repository is in detached HEAD state, replace the fallback `HEAD` label with the tag name; otherwise append the tag next to the branch to make release and hotfix context immediately visible.

---

Commit message by AI. Code change by me.